### PR TITLE
Add merge_group to piptest

### DIFF
--- a/.github/workflows/piptest.yml
+++ b/.github/workflows/piptest.yml
@@ -4,6 +4,7 @@ on:
     paths:
       - 'docs/**/*.py'
       - 'pytest.ini'
+  merge_group:
   pull_request:
     types: [opened, synchronize, reopened]
   schedule:


### PR DESCRIPTION
This allows the workflow to be run as a part of the merge queue.