### PR TITLE
Move creation of iterator into lambda

### DIFF
--- a/src/sedpack/io/dataset_iteration.py
+++ b/src/sedpack/io/dataset_iteration.py
@@ -235,7 +235,7 @@ class DatasetIteration(DatasetBase):
                     shards=shards,
                     shard_filter=shard_filter,
                     repeat=repeat,
-                    file_parallelism=file_parallelism,
+                    file_parallelism=file_parallelism or 1,
                     shuffle=shuffle,
                 ),
                 output_signature=output_signature,

--- a/src/sedpack/io/dataset_iteration.py
+++ b/src/sedpack/io/dataset_iteration.py
@@ -223,22 +223,21 @@ class DatasetIteration(DatasetBase):
         # The user requested a tf.data.Dataset use as_numpy_iterator_concurrent
         # to provide.
         if self.dataset_structure.shard_file_type != "tfrec":
-            example_iterator = self.as_numpy_iterator_concurrent(
-                split=split,
-                process_record=None,  # otherwise unknown tensorspec
-                shards=shards,
-                shard_filter=shard_filter,
-                repeat=repeat,
-                file_parallelism=file_parallelism or 1,
-                shuffle=shuffle,
-            )
             output_signature = {
                 attribute.name:
                     tf.TensorSpec(shape=attribute.shape, dtype=attribute.dtype)
                 for attribute in self.dataset_structure.saved_data_description
             }
             tf_dataset = tf.data.Dataset.from_generator(
-                lambda: example_iterator,
+                lambda: self.as_numpy_iterator_concurrent(
+                    split=split,
+                    process_record=None,  # otherwise unknown tensorspec
+                    shards=shards,
+                    shard_filter=shard_filter,
+                    repeat=repeat,
+                    file_parallelism=file_parallelism,
+                    shuffle=shuffle,
+                ),
                 output_signature=output_signature,
             )
             if process_record:


### PR DESCRIPTION
The function `tf.data.Dataset.from_generator` is taking a callable returning an iterator. This can get called multiple times even when the iterator does not end (raise an StopIteration). Thus eventually causing an `ValueError: generator already executing`.