### PR TITLE
Implement limiting the number of shard types

### DIFF
--- a/src/sedpack/io/dataset_base.py
+++ b/src/sedpack/io/dataset_base.py
@@ -146,7 +146,8 @@ class DatasetBase:
 
         Args:
 
-          split (SplitT): Which split to iterate shard information from.
+          split (SplitT | None): Which split to iterate shard information from.
+          If None then all splits are iterated.
 
         Raises: ValueError when the split is not present. A split not being
         present is different from there not being any shard.

--- a/src/sedpack/io/dataset_iteration.py
+++ b/src/sedpack/io/dataset_iteration.py
@@ -103,7 +103,7 @@ class DatasetIteration(DatasetBase):
         # Only use a limited amount of shards for each setting of
         # custom_metadata.
         if custom_metadata_type_limit:
-            counts: dict[tuple[tuple[str, Any]], int] = {}
+            counts: dict[tuple[tuple[str, Any], ...], int] = {}
             old_shards_list = shards_list
             shards_list = []
             for shard_info in old_shards_list:

--- a/src/sedpack/io/dataset_iteration.py
+++ b/src/sedpack/io/dataset_iteration.py
@@ -478,6 +478,7 @@ class DatasetIteration(DatasetBase):
         split: SplitT,
         process_record: Optional[Callable[[ExampleT], T]] = None,
         shards: Optional[int] = None,
+        custom_metadata_type_limit: int | None = None,
         shard_filter: Optional[Callable[[ShardInfo], bool]] = None,
         repeat: bool = True,
         file_parallelism: int = os.cpu_count() or 1,
@@ -495,6 +496,12 @@ class DatasetIteration(DatasetBase):
 
             shards (Optional[int]): If specified limits the dataset to the
             first `shards` shards.
+
+            custom_metadata_type_limit (int | None): Ignored when None. If
+            non-zero then limit the number of shards with different
+            `custom_metadata`. Take only the first `custom_metadata_type_limit`
+            shards with the concrete `custom_metadata`. This is best effort for
+            different `custom_metadata` (hashed as a tuple of sorted items).
 
             shard_filter (Optional[Callable[[ShardInfo], bool]): If present
             this is a function taking the ShardInfo and returning True if the
@@ -516,6 +523,7 @@ class DatasetIteration(DatasetBase):
         shard_paths_iterator: Iterable[str] = self._as_numpy_common(
             split=split,
             shards=shards,
+            custom_metadata_type_limit=custom_metadata_type_limit,
             shard_filter=shard_filter,
             repeat=repeat,
             shuffle=shuffle,
@@ -587,6 +595,7 @@ class DatasetIteration(DatasetBase):
         split: SplitT,
         process_record: Optional[Callable[[ExampleT], T]] = None,
         shards: Optional[int] = None,
+        custom_metadata_type_limit: int | None = None,
         shard_filter: Optional[Callable[[ShardInfo], bool]] = None,
         repeat: bool = True,
         shuffle: int = 1_000,
@@ -603,6 +612,12 @@ class DatasetIteration(DatasetBase):
 
             shards (Optional[int]): If specified limits the dataset to the
             first `shards` shards.
+
+            custom_metadata_type_limit (int | None): Ignored when None. If
+            non-zero then limit the number of shards with different
+            `custom_metadata`. Take only the first `custom_metadata_type_limit`
+            shards with the concrete `custom_metadata`. This is best effort for
+            different `custom_metadata` (hashed as a tuple of sorted items).
 
             shard_filter (Optional[Callable[[ShardInfo], bool]): If present
             this is a function taking the ShardInfo and returning True if the
@@ -621,6 +636,7 @@ class DatasetIteration(DatasetBase):
         shard_paths_iterator: Iterable[str] = self._as_numpy_common(
             split=split,
             shards=shards,
+            custom_metadata_type_limit=custom_metadata_type_limit,
             shard_filter=shard_filter,
             repeat=repeat,
             shuffle=shuffle,

--- a/src/sedpack/io/dataset_iteration.py
+++ b/src/sedpack/io/dataset_iteration.py
@@ -100,9 +100,10 @@ class DatasetIteration(DatasetBase):
         if shards:
             shards_list = shards_list[:shards]
 
-        # Only use a limited amount of shards for each setting of custom_metadata.
+        # Only use a limited amount of shards for each setting of
+        # custom_metadata.
         if custom_metadata_type_limit:
-            counts = {}
+            counts: dict[tuple[tuple[str, Any]], int] = {}
             old_shards_list = shards_list
             shards_list = []
             for shard_info in old_shards_list:

--- a/tests/io/test_custom_metadata_type_limit.py
+++ b/tests/io/test_custom_metadata_type_limit.py
@@ -1,0 +1,169 @@
+# Copyright 2023-2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from typing import Any, Union
+
+import numpy as np
+import numpy.typing as npt
+
+import sedpack
+from sedpack.io import Dataset
+from sedpack.io import Metadata, DatasetStructure, Attribute
+from sedpack.io.types import TRAIN_SPLIT, CompressionT, ShardFileTypeT
+
+
+def end2end(tmpdir: Union[str, Path], dtype: npt.DTypeLike, method: str,
+            shard_file_type: ShardFileTypeT, compression: CompressionT) -> None:
+    examples_per_shard: int = 256
+    array_of_values = np.random.random((examples_per_shard * 5, 138))
+    array_of_values = array_of_values.astype(dtype)
+    custom_metadata_type_limit: int = array_of_values.shape[0] // examples_per_shard
+
+    tiny_experiment_path: Path = Path(tmpdir) / "e2e_experiment"
+
+    # Create a dataset
+
+    dataset_metadata = Metadata(description="Test of the lib")
+
+    example_attributes = [
+        sedpack.io.metadata.Attribute(
+            name="attribute_name",
+            dtype=str(dtype),
+            shape=array_of_values[0].shape,
+        ),
+    ]
+
+    dataset_structure = sedpack.io.metadata.DatasetStructure(
+        saved_data_description=example_attributes,
+        compression=compression,
+        examples_per_shard=examples_per_shard,
+        shard_file_type=shard_file_type,
+    )
+
+    dataset = Dataset.create(
+        path=tiny_experiment_path,
+        metadata=dataset_metadata,
+        dataset_structure=dataset_structure,
+    )
+
+    # Fill data in the dataset
+
+    with dataset.filler() as filler:
+        for attribute_value in array_of_values:
+            filler.write_example(
+                values={"attribute_name": attribute_value},
+                split=TRAIN_SPLIT,
+                custom_metadata={"take": "me", "some_number": 0},
+            )
+
+        for attribute_value in array_of_values:
+            filler.write_example(
+                values={"attribute_name": attribute_value},
+                split=TRAIN_SPLIT,
+                custom_metadata={"some_number": 0, "take": "me"},  # same, so ignored
+            )
+
+    # Check the data is correct
+    # Reopen the dataset
+    dataset = Dataset(tiny_experiment_path)
+    dataset.check()
+
+    match method:
+        case "as_tfdataset":
+            for i, example in enumerate(
+                    dataset.as_tfdataset(
+                        split=TRAIN_SPLIT,
+                        shuffle=0,
+                        repeat=False,
+                        batch_size=1,
+                        custom_metadata_type_limit=custom_metadata_type_limit,
+                    )):
+                assert np.allclose(example["attribute_name"],
+                                   array_of_values[i:i + 1])
+        case "as_numpy_iterator":
+            for i, example in enumerate(
+                    dataset.as_numpy_iterator(
+                        split=TRAIN_SPLIT,
+                        shuffle=0,
+                        repeat=False,
+                        custom_metadata_type_limit=custom_metadata_type_limit,
+                    )):
+                assert np.allclose(example["attribute_name"],
+                                   array_of_values[i])
+        case "as_numpy_iterator_concurrent":
+            for i, example in enumerate(
+                    dataset.as_numpy_iterator_concurrent(
+                        split=TRAIN_SPLIT,
+                        shuffle=0,
+                        repeat=False,
+                        custom_metadata_type_limit=custom_metadata_type_limit,
+                    )):
+                assert np.allclose(example["attribute_name"],
+                                   array_of_values[i])
+
+    # We tested everything
+    assert i + 1 == array_of_values.shape[
+        0], "Not all examples have been iterated"
+
+
+def test_end2end_as_tfdataset_tfrec_float32_float32(
+        tmpdir: Union[str, Path]) -> None:
+    end2end(tmpdir=tmpdir,
+            dtype="float32",
+            method="as_tfdataset",
+            shard_file_type="tfrec",
+            compression="GZIP")
+
+
+def test_end2end_as_numpy_iterator_concurrent_tfrec(
+        tmpdir: Union[str, Path]) -> None:
+    end2end(tmpdir=tmpdir,
+            dtype="float32",
+            method="as_numpy_iterator_concurrent",
+            shard_file_type="tfrec",
+            compression="GZIP")
+
+
+def test_end2end_as_numpy_iterator_tfrec(tmpdir: Union[str, Path]) -> None:
+    end2end(tmpdir=tmpdir,
+            dtype="float32",
+            method="as_numpy_iterator",
+            shard_file_type="tfrec",
+            compression="GZIP")
+
+
+def test_end2end_as_numpy_iterator_npz(tmpdir: Union[str, Path]) -> None:
+    end2end(tmpdir=tmpdir,
+            dtype="float32",
+            method="as_numpy_iterator",
+            shard_file_type="npz",
+            compression="ZIP")
+
+
+def test_end2end_as_numpy_iterator_concurrent_fb(
+        tmpdir: Union[str, Path]) -> None:
+    end2end(tmpdir=tmpdir,
+            dtype="float32",
+            method="as_numpy_iterator_concurrent",
+            shard_file_type="fb",
+            compression="LZ4")
+
+
+def test_end2end_as_numpy_iterator_fb(tmpdir: Union[str, Path]) -> None:
+    end2end(tmpdir=tmpdir,
+            dtype="float32",
+            method="as_numpy_iterator",
+            shard_file_type="fb",
+            compression="LZ4")

--- a/tests/io/test_custom_metadata_type_limit.py
+++ b/tests/io/test_custom_metadata_type_limit.py
@@ -29,7 +29,8 @@ def end2end(tmpdir: Union[str, Path], dtype: npt.DTypeLike, method: str,
     examples_per_shard: int = 256
     array_of_values = np.random.random((examples_per_shard * 5, 138))
     array_of_values = array_of_values.astype(dtype)
-    custom_metadata_type_limit: int = array_of_values.shape[0] // examples_per_shard
+    custom_metadata_type_limit: int = array_of_values.shape[
+        0] // examples_per_shard
 
     tiny_experiment_path: Path = Path(tmpdir) / "e2e_experiment"
 
@@ -65,14 +66,20 @@ def end2end(tmpdir: Union[str, Path], dtype: npt.DTypeLike, method: str,
             filler.write_example(
                 values={"attribute_name": attribute_value},
                 split=TRAIN_SPLIT,
-                custom_metadata={"take": "me", "some_number": 0},
+                custom_metadata={
+                    "take": "me",
+                    "some_number": 0
+                },
             )
 
         for attribute_value in array_of_values:
             filler.write_example(
                 values={"attribute_name": attribute_value},
                 split=TRAIN_SPLIT,
-                custom_metadata={"some_number": 0, "take": "me"},  # same, so ignored
+                custom_metadata={
+                    "some_number": 0,
+                    "take": "me"
+                },  # same, so ignored
             )
 
     # Check the data is correct


### PR DESCRIPTION
Implement limiting the number of shards with a given `custom_metadata` resulting in using at most a `custom_metadata_type_limit` shards of the same `custom_metadata`. This is useful for experiments with how much data is needed to train a neural network (say with `custom_metadata` denoting the uniform content type in the whole shard).