### PR TITLE
Remove workaround to install dependencies

### DIFF
--- a/.github/workflows/maturin_ci.yml
+++ b/.github/workflows/maturin_ci.yml
@@ -55,7 +55,6 @@ jobs:
           python3 -m venv .venv
           source .venv/bin/activate
           pip install sedpack --find-links dist --force-reinstall
-          pip install --require-hashes --no-deps -r requirements.txt # TODO workaround
           pip install pytest
           pytest
       - name: pytest
@@ -71,7 +70,6 @@ jobs:
             pip3 install -U pip pytest
           run: |
             set -e
-            pip3 install --require-hashes --no-deps -r requirements.txt # TODO workaround
             pip3 install sedpack --find-links dist --force-reinstall
             pytest
 


### PR DESCRIPTION
Since we are releasing to PyPI there is no longer a need to install dependencies in the package testing workflow. Fixes issue #63