### PR TITLE
Fix track of benchmarks

### DIFF
--- a/.github/workflows/fork_pr_benchmarks_track.yml
+++ b/.github/workflows/fork_pr_benchmarks_track.yml
@@ -18,6 +18,7 @@ jobs:
         uses: dawidd6/action-download-artifact@v6
         with:
           name: rust_target_criterion
+          path: rust/target/criterion
           run_id: ${{ github.event.workflow_run.id }}
       - name: Download PR Event
         uses: dawidd6/action-download-artifact@v6


### PR DESCRIPTION
The artifact is expected in the directory rust/target/criterion