### PR TITLE
Move parsing of examples into get_shard_progress

### DIFF
--- a/rust/src/example_iteration.rs
+++ b/rust/src/example_iteration.rs
@@ -143,7 +143,7 @@ fn read_to_end(mut reader: impl std::io::Read) -> Vec<u8> {
 }
 
 /// Get ShardProgress.
-pub fn get_shard_progress(shard_info: &ShardInfo) -> ShardProgress {
+pub fn get_shard_progress(shard_info: &ShardInfo) -> Vec<Example> {
     let file_bytes = get_file_bytes(shard_info);
 
     // A shard is a vector of examples (positive number -- invariant kept by Python code).
@@ -157,7 +157,7 @@ pub fn get_shard_progress(shard_info: &ShardInfo) -> ShardProgress {
     // Number of examples might be different in different shards.
     let total_examples = shard.get().examples().unwrap().len();
 
-    ShardProgress { total_examples, used_examples: 0, shard }
+    ShardProgress { total_examples, used_examples: 0, shard }.collect()
 }
 
 /// Get single example out of a ShardProgress.


### PR DESCRIPTION
This moves the parsing and creation of examples into the threads making ExampleIterator faster and as a consequence the call to get_shard_progress slower.