### PR TITLE
Add a helper to retrieve an attribute by name

### DIFF
--- a/src/sedpack/io/metadata.py
+++ b/src/sedpack/io/metadata.py
@@ -130,6 +130,23 @@ class DatasetStructure(BaseModel):
     shard_file_type: ShardFileTypeT = "tfrec"
     hash_checksum_algorithms: tuple[HashChecksumT, ...] = ("sha256",)
 
+    def attribute_by_name(self, attribute_name: str) -> Attribute:
+        """Return the attribute of the given name or raise a ValueError if not
+        present.
+
+        Args:
+
+          attribute_name (str): The name of the attribute we want.
+
+        Returns: the attribute object if found.
+
+        Raises: ValueError if no attribute of this name is present.
+        """
+        for attribute in self.saved_data_description:
+            if attribute_name == attribute.name:
+                return attribute
+        raise ValueError(f"No attribute named {attribute_name}")
+
 
 class DatasetInfo(BaseModel):
     """Holds all information saved in the main metadata file

--- a/tests/io/test_end2end.py
+++ b/tests/io/test_end2end.py
@@ -50,6 +50,11 @@ def end2end(tmpdir: Union[str, Path], dtype: npt.DTypeLike, method: str,
         shard_file_type=shard_file_type,
     )
 
+    # Test attribute_by_name
+    for attribute in example_attributes:
+        assert dataset_structure.attribute_by_name(
+            attribute_name=attribute.name) == attribute
+
     dataset = Dataset.create(
         path=tiny_experiment_path,
         metadata=dataset_metadata,


### PR DESCRIPTION
Retrieve an attribute object by a given name. Useful when getting the attribute metadata without the need to manually loop the saved_data_description.