### PR TITLE
Fix Pylint not-an-iterable

### DIFF
--- a/src/sedpack/io/metadata.py
+++ b/src/sedpack/io/metadata.py
@@ -124,7 +124,7 @@ class DatasetStructure(BaseModel):
         hash_checksum_algorithms (tuple[HashChecksumT, ...]): Which hash
         algorithms should be computed for file hash checksums.
     """
-    saved_data_description: list[Attribute] = Field(default_factory=list)
+    saved_data_description: list[Attribute] = []
     compression: CompressionT = "GZIP"
     examples_per_shard: int = 256
     shard_file_type: ShardFileTypeT = "tfrec"


### PR DESCRIPTION
Line 145 was mis-diagnosed as iterating an non-iterable Field. This Field was used to store a default factory instead of using mutable default. However Pydantic allows mutable defaults and handles them correctly.