### PR TITLE
Set __version__ dynamically in __init__.py

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "sedpack_rs"
-version = "0.1.3"
 edition = "2021"
 description = "Rust bindings for sedpack a general ML dataset package"
 authors = [

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "sedpack_rs"
+version = "0.1.3"
 edition = "2021"
 description = "Rust bindings for sedpack a general ML dataset package"
 authors = [

--- a/src/sedpack/__init__.py
+++ b/src/sedpack/__init__.py
@@ -25,7 +25,9 @@ import importlib
 # compatibility with existing code we dynamically set the __version__ attribute
 # here.
 try:
+    # When package is installed use the version.
     __version__ = importlib.metadata.version("sedpack")
 except importlib.metadata.PackageNotFoundError:
-    # Package is not installed. This is expected for local development.
-    __version__ = "0.0.0-dev"
+    # Package is not installed. The Rust part of this package is probably not
+    # going to work in this case (the Rust binding would be probably missing).
+    __version__ = "0.0.7-dev"

--- a/src/sedpack/__init__.py
+++ b/src/sedpack/__init__.py
@@ -24,4 +24,8 @@ import importlib
 # https://www.maturin.rs/metadata.html#dynamic-metadata). To ensure
 # compatibility with existing code we dynamically set the __version__ attribute
 # here.
-__version__ = importlib.metadata.version("sedpack")
+try:
+    __version__ = importlib.metadata.version("sedpack")
+except importlib.metadata.PackageNotFoundError:
+    # Package is not installed. This is expected for local development.
+    __version__ = "0.0.0-dev"

--- a/src/sedpack/__init__.py
+++ b/src/sedpack/__init__.py
@@ -13,9 +13,15 @@
 # limitations under the License.
 """Dataset library.
 
-Format: MAJOR.MINOR.PATCH (see https://pypi.org/project/semver/ for more
-  possibilities)
+Version format: MAJOR.MINOR.PATCH (see https://pypi.org/project/semver/ for
+more possibilities).
 """
-# The version of this package is defined by rust/Cargo.toml but mypy does not
-# see that.
-__version__ = "0.1.3"
+
+import importlib
+
+# The version of this package is defined by rust/Cargo.toml and dynamically
+# deduced by Maturin (see
+# https://www.maturin.rs/metadata.html#dynamic-metadata). To ensure
+# compatibility with existing code we dynamically set the __version__ attribute
+# here.
+__version__ = importlib.metadata.version("sedpack")


### PR DESCRIPTION
The version of the Sedpack package is dynamically determined by Maturin based on the version string in rust/Cargo.toml. Remove the redundancy in __init__.py file.

Fixes https://github.com/google/sedpack/issues/145