### PR TITLE
RustIter does not support repeat

### DIFF
--- a/rust/benches/my_benchmark.rs
+++ b/rust/benches/my_benchmark.rs
@@ -37,7 +37,7 @@ pub fn example_iterator_benchmark(c: &mut Criterion) {
     let shard_infos = get_shard_files();
     c.bench_function("ExampleIterator", |b| {
         b.iter(|| {
-            for example in ExampleIterator::new(shard_infos.clone(), false, 12) {
+            for example in ExampleIterator::new(shard_infos.clone(), 12) {
                 let _ = std::hint::black_box(example);
             }
         })

--- a/rust/src/example_iteration.rs
+++ b/rust/src/example_iteration.rs
@@ -98,8 +98,7 @@ impl ExampleIterator {
     /// - Iterate over the shards in Rust. This would require having the shard filtering being
     ///   allowed to be called from Rust. But then we could pass an iterator of the following form:
     ///   `files: impl Iterator<Item = &str>`.
-    pub fn new(files: Vec<ShardInfo>, repeat: bool, threads: usize) -> Self {
-        assert!(!repeat, "Not implemented yet: repeat=true");
+    pub fn new(files: Vec<ShardInfo>, threads: usize) -> Self {
         let example_iterator = Box::new(
             parallel_map(|x| get_shard_progress(&x), files.into_iter(), threads).flatten(),
         );

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -94,7 +94,7 @@ mod static_iter {
             let compression_type = CompressionType::from_str(&compression).unwrap();
             let shard_infos = files
                 .into_iter()
-                .map(|file_path| ShardInfo { file_path: file_path.clone(), compression_type })
+                .map(|file_path| ShardInfo { file_path: file_path, compression_type })
                 .collect();
             hash_map.insert(static_index, ExampleIterator::new(shard_infos, threads));
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -88,7 +88,7 @@ mod static_iter {
     #[pymethods]
     impl RustIter {
         #[new]
-        fn new(files: Vec<String>, repeat: bool, threads: usize, compression: String) -> Self {
+        fn new(files: Vec<String>, threads: usize, compression: String) -> Self {
             let static_index = rand::random();
             let mut hash_map = STATIC_ITERATORS.lock().unwrap();
             let compression_type = CompressionType::from_str(&compression).unwrap();
@@ -96,7 +96,7 @@ mod static_iter {
                 .into_iter()
                 .map(|file_path| ShardInfo { file_path: file_path.clone(), compression_type })
                 .collect();
-            hash_map.insert(static_index, ExampleIterator::new(shard_infos, repeat, threads));
+            hash_map.insert(static_index, ExampleIterator::new(shard_infos, threads));
 
             RustIter { static_index, can_iterate: false }
         }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -94,7 +94,7 @@ mod static_iter {
             let compression_type = CompressionType::from_str(&compression).unwrap();
             let shard_infos = files
                 .into_iter()
-                .map(|file_path| ShardInfo { file_path: file_path, compression_type })
+                .map(|file_path| ShardInfo { file_path, compression_type })
                 .collect();
             hash_map.insert(static_index, ExampleIterator::new(shard_infos, threads));
 

--- a/src/sedpack/io/iteration/rust_generator.py
+++ b/src/sedpack/io/iteration/rust_generator.py
@@ -185,7 +185,6 @@ class RustGenerator:
                 files=shard_paths,
                 threads=self._file_parallelism,
                 compression=self._dataset_structure.compression,
-                repeat=False,
             )
             # Manually calling __enter__ and __exit__ -- see class docstring.
             self._rust_iter.__enter__()  # pylint: disable=unnecessary-dunder-call


### PR DESCRIPTION
Remove the option which was not implemented anyway. Now the shard order is given by a custom ShardInfo iterator implemented in Python.

https://github.com/google/sedpack/issues/200