### PR TITLE
Fix Rust benchmarking

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -234,6 +234,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "half"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,6 +687,7 @@ dependencies = [
  "criterion",
  "flatbuffers",
  "flate2",
+ "glob",
  "lz4_flex",
  "numpy",
  "pyo3",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -22,6 +22,7 @@ crate-type = ["cdylib", "rlib"]
 criterion = "0.7.0"
 flatbuffers = "25.2"
 flate2 = { version = "1.1.0" }
+glob = "0.3.3"
 lz4_flex = { version = "0.11.3", default-features = false , features = ["frame"] }
 numpy = "0.24"
 pyo3 = "0.24"

--- a/rust/benches/my_benchmark.rs
+++ b/rust/benches/my_benchmark.rs
@@ -55,9 +55,5 @@ pub fn parallel_map_benchmark(c: &mut Criterion) {
     });
 }
 
-criterion_group!(
-    benches,
-    example_iterator_benchmark,
-    parallel_map_benchmark,
-);
+criterion_group!(benches, example_iterator_benchmark, parallel_map_benchmark,);
 criterion_main!(benches);

--- a/rust/benches/my_benchmark.rs
+++ b/rust/benches/my_benchmark.rs
@@ -27,7 +27,7 @@ pub fn get_shard_files() -> Vec<ShardInfo> {
         .map(|file_path| ShardInfo { file_path, compression_type: CompressionType::Gzip })
         .collect();
     println!(">> Decoding {} shards", shard_infos.len());
-    assert!(shard_infos.len() == 275);
+    assert_eq!(shard_infos.len(), 275);
     shard_infos
 }
 


### PR DESCRIPTION
Pull request https://github.com/google/sedpack/pull/171 introduced a problem with benchmarking code rendering it useless. This commit traverses the dataset directory recursively and thus again introduces meaningful benchmarking. Also it makes sure that we traverse the expected number of shards.

This commit includes also test and holdout splits to benchmarking since when we have that data we might use it. This will introduce a regression compared to the first benchmarks and definitely one compared to the empty benchmarks.