### PR TITLE
Fix importlib import

### DIFF
--- a/src/sedpack/__init__.py
+++ b/src/sedpack/__init__.py
@@ -17,7 +17,7 @@ Version format: MAJOR.MINOR.PATCH (see https://pypi.org/project/semver/ for
 more possibilities).
 """
 
-from importlib.metadata import version
+from importlib.metadata import version, PackageNotFoundError
 
 # The version of this package is defined by rust/Cargo.toml and dynamically
 # deduced by Maturin (see
@@ -27,7 +27,7 @@ from importlib.metadata import version
 try:
     # When package is installed use the version.
     __version__ = version("sedpack")
-except importlib.metadata.PackageNotFoundError:
+except PackageNotFoundError:
     # Package is not installed. The Rust part of this package is probably not
     # going to work in this case (the Rust binding would be probably missing).
     __version__ = "0.0.7-dev"

--- a/src/sedpack/__init__.py
+++ b/src/sedpack/__init__.py
@@ -17,7 +17,7 @@ Version format: MAJOR.MINOR.PATCH (see https://pypi.org/project/semver/ for
 more possibilities).
 """
 
-import importlib
+from importlib.metadata import version
 
 # The version of this package is defined by rust/Cargo.toml and dynamically
 # deduced by Maturin (see
@@ -26,7 +26,7 @@ import importlib
 # here.
 try:
     # When package is installed use the version.
-    __version__ = importlib.metadata.version("sedpack")
+    __version__ = version("sedpack")
 except importlib.metadata.PackageNotFoundError:
     # Package is not installed. The Rust part of this package is probably not
     # going to work in this case (the Rust binding would be probably missing).


### PR DESCRIPTION
There was a bug that this package depended on importlib-metadata instead of the Python3.8 importlib module. When importlib-metadata was not installed the following error would show:
AttributeError: module 'importlib' has no attribute 'metadata' https://docs.python.org/3/library/importlib.metadata.html

Followup of https://github.com/google/sedpack/pull/217