### PR TITLE
Conditionally install patchelf

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,8 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "maturin",
+    "maturin[patchelf] ; platform_system != 'Windows'",
+    "maturin ; platform_system == 'Windows'",
     "mypy",
     "pylint",
     "pytest",


### PR DESCRIPTION
Set dev dependencies to conditionally install patchelf. On the Windows worker on GitHub patchelf was failing to build. On the other hand it is useful on other platforms.