### PR TITLE
Improve Rust batching

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -762,9 +762,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
@@ -772,9 +772,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -857,6 +857,7 @@ dependencies = [
  "numpy",
  "pyo3",
  "rand 0.9.0",
+ "rayon",
  "strum",
  "strum_macros",
  "tracing",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -27,6 +27,7 @@ lz4_flex = { version = "0.11.3", default-features = false , features = ["frame"]
 numpy = "0.24"
 pyo3 = "0.24"
 rand = "0.9"
+rayon = "1.11.0"
 strum = "0.27.0"
 strum_macros = "0.27.0"
 tracing = "0.1.41"

--- a/rust/src/batch_iteration.rs
+++ b/rust/src/batch_iteration.rs
@@ -118,14 +118,13 @@ impl BatchingData {
                                 .indexes
                                 .par_iter()
                                 .map(|batching_index| {
-                                    numpy::ndarray::Array::<u8, numpy::Ix1>::from_iter(
+                                    numpy::ndarray::Array::<u8, numpy::Ix1>::from_vec(
                                         self.shards[batching_index.shards_index]
                                             .borrow_attribute(
                                                 batching_index.example_index,
                                                 attribute_id,
                                             )
-                                            .iter()
-                                            .cloned(),
+                                            .to_vec(),
                                     )
                                 })
                                 .collect(),

--- a/rust/src/example_iteration.rs
+++ b/rust/src/example_iteration.rs
@@ -191,6 +191,44 @@ fn get_example(id: usize, shard_progress: &ShardProgress) -> Example {
     attributes.iter().map(|x| x.attribute_bytes().unwrap().iter().collect()).collect()
 }
 
+impl ShardProgress {
+    /// Return a slice representing the bytes of a single attribute (without copy).
+    pub fn borrow_attribute(&self, example_id: usize, attribute_id: usize) -> &[u8] {
+        assert!(example_id < self.total_examples);
+
+        let examples = self.shard.get().examples().unwrap();
+
+        // Should not happen but there is no control over this invariant in Rust.
+        assert!(!examples.is_empty());
+
+        examples
+            .get(example_id)
+            .attributes()
+            .unwrap()
+            .get(attribute_id)
+            .attribute_bytes()
+            .unwrap()
+            .bytes()
+    }
+
+    /// Return the example id which is to be used next. Beware that this method also consumes it
+    /// (and thus might consume the ShardProgress for the Iterator::next calls).
+    pub fn next_example_id(&mut self) -> Option<usize> {
+        if self.used_examples < self.total_examples {
+            let result = Some(self.used_examples);
+            self.used_examples += 1;
+            result
+        } else {
+            None
+        }
+    }
+
+    /// Has more elements either as Iterator::next or ShardProgress::next_example_id?
+    pub fn has_next(&self) -> bool {
+        self.used_examples < self.total_examples
+    }
+}
+
 impl Iterator for ShardProgress {
     type Item = Example;
 


### PR DESCRIPTION
Remove unnecessary copy from Rust library when batching. Enable parallel memcpy. Based on preliminary benchmarks this is ~3x faster.

Part of https://github.com/google/sedpack/issues/200