### PR TITLE
Skip unnecessary workflows on forks

### DIFF
--- a/.github/workflows/base_benchmarks.yml
+++ b/.github/workflows/base_benchmarks.yml
@@ -15,6 +15,8 @@ on:
 
 jobs:
   benchmark_base_branch:
+    # Run only on the upstream repository.
+    if: github.repository == 'google/sedpack'
     name: Continuous Benchmarking with Bencher
     permissions:
       checks: write

--- a/.github/workflows/fork_pr_benchmarks_run.yml
+++ b/.github/workflows/fork_pr_benchmarks_run.yml
@@ -14,6 +14,8 @@ on:
 
 jobs:
   benchmark_fork_pr_branch:
+    # Run only on the upstream repository.
+    if: github.repository == 'google/sedpack'
     name: Run Fork PR Benchmarks
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/maturin_ci.yml
+++ b/.github/workflows/maturin_ci.yml
@@ -162,6 +162,8 @@ jobs:
           path: dist
 
   release:
+    # Run only on the upstream repository.
+    if: github.repository == 'google/sedpack'
     # https://www.maturin.rs/distribution.html Using PyPI's trusted publishing
     name: Release
     runs-on: ubuntu-latest


### PR DESCRIPTION
Skip workflows from running in fork when they need to run on the upstream repository.