### PR TITLE
Bump Rust edition to 2024

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sedpack_rs"
 version = "0.1.4"
-edition = "2021"
+edition = "2024"
 description = "Rust bindings for sedpack a general ML dataset package"
 authors = [
     "Elie Bursztein",

--- a/rust/benches/my_benchmark.rs
+++ b/rust/benches/my_benchmark.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use glob::glob;
 use sedpack_rs::batch_iteration::BatchIterator;
 use sedpack_rs::example_iteration::{
-    get_shard_progress, CompressionType, ExampleIterator, ShardInfo,
+    CompressionType, ExampleIterator, ShardInfo, get_shard_progress,
 };
 pub use sedpack_rs::parallel_map::parallel_map;
 

--- a/rust/src/batch_iteration.rs
+++ b/rust/src/batch_iteration.rs
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 use rayon::prelude::*;
-use tracing::{span, Level};
+use tracing::{Level, span};
 
 pub use super::example_iteration::{
-    get_shard_progress, CompressionType, Example, ExampleIterator, ShardInfo, ShardProgress,
+    CompressionType, Example, ExampleIterator, ShardInfo, ShardProgress, get_shard_progress,
 };
 pub use super::parallel_map::parallel_map;
-pub use super::shard_generated::sedpack::io::flatbuffer::shardfile::{root_as_shard, Shard};
+pub use super::shard_generated::sedpack::io::flatbuffer::shardfile::{Shard, root_as_shard};
 
 /// Single attribute which has been batched.
 pub enum BatchedAttribute {

--- a/rust/src/example_iteration.rs
+++ b/rust/src/example_iteration.rs
@@ -18,7 +18,7 @@ use tracing::instrument;
 use yoke::Yoke;
 
 pub use super::parallel_map::parallel_map;
-pub use super::shard_generated::sedpack::io::flatbuffer::shardfile::{root_as_shard, Shard};
+pub use super::shard_generated::sedpack::io::flatbuffer::shardfile::{Shard, root_as_shard};
 
 pub type Example = Vec<Vec<u8>>;
 type LoadedShard = Yoke<Shard<'static>, Vec<u8>>;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -14,7 +14,7 @@
 
 use pyo3::prelude::*;
 pub use shard_generated::sedpack::io::flatbuffer::shardfile::{
-    root_as_shard, root_as_shard_unchecked, Attribute, Example, Shard,
+    Attribute, Example, Shard, root_as_shard, root_as_shard_unchecked,
 };
 
 pub mod batch_iteration;
@@ -32,7 +32,7 @@ mod static_iter {
 
     use numpy::IntoPyArray;
     use pyo3::prelude::*;
-    use pyo3::{pyclass, pymethods, PyRefMut};
+    use pyo3::{PyRefMut, pyclass, pymethods};
 
     use super::example_iteration::{CompressionType, ExampleIterator, ShardInfo};
 
@@ -158,8 +158,8 @@ mod static_batched_iter {
 
     use numpy::IntoPyArray;
     use pyo3::prelude::*;
-    use pyo3::{pyclass, pymethods, PyRefMut};
-    use tracing::{span, Level};
+    use pyo3::{PyRefMut, pyclass, pymethods};
+    use tracing::{Level, span};
 
     use super::batch_iteration::{BatchIterator, BatchedAttribute};
     use super::example_iteration::{CompressionType, ShardInfo};

--- a/rust/src/shard_generated.rs
+++ b/rust/src/shard_generated.rs
@@ -53,9 +53,9 @@ pub mod sedpack {
                 impl<'a> flatbuffers::Follow<'a> for Attribute<'a> {
                     type Inner = Attribute<'a>;
                     #[inline]
-                    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+                    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner { unsafe {
                         Self { _tab: flatbuffers::Table::new(buf, loc) }
-                    }
+                    }}
                 }
 
                 impl<'a> Attribute<'a> {
@@ -166,9 +166,9 @@ pub mod sedpack {
                 impl<'a> flatbuffers::Follow<'a> for Example<'a> {
                     type Inner = Example<'a>;
                     #[inline]
-                    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+                    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner { unsafe {
                         Self { _tab: flatbuffers::Table::new(buf, loc) }
-                    }
+                    }}
                 }
 
                 impl<'a> Example<'a> {
@@ -288,9 +288,9 @@ pub mod sedpack {
                 impl<'a> flatbuffers::Follow<'a> for Shard<'a> {
                     type Inner = Shard<'a>;
                     #[inline]
-                    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+                    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner { unsafe {
                         Self { _tab: flatbuffers::Table::new(buf, loc) }
-                    }
+                    }}
                 }
 
                 impl<'a> Shard<'a> {
@@ -449,16 +449,16 @@ pub mod sedpack {
                 /// Assumes, without verification, that a buffer of bytes contains a Shard and returns it.
                 /// # Safety
                 /// Callers must trust the given bytes do indeed contain a valid `Shard`.
-                pub unsafe fn root_as_shard_unchecked(buf: &[u8]) -> Shard<'_> {
+                pub unsafe fn root_as_shard_unchecked(buf: &[u8]) -> Shard<'_> { unsafe {
                     flatbuffers::root_unchecked::<Shard>(buf)
-                }
+                }}
                 #[inline]
                 /// Assumes, without verification, that a buffer of bytes contains a size prefixed Shard and returns it.
                 /// # Safety
                 /// Callers must trust the given bytes do indeed contain a valid size prefixed `Shard`.
-                pub unsafe fn size_prefixed_root_as_shard_unchecked(buf: &[u8]) -> Shard<'_> {
+                pub unsafe fn size_prefixed_root_as_shard_unchecked(buf: &[u8]) -> Shard<'_> { unsafe {
                     flatbuffers::size_prefixed_root_unchecked::<Shard>(buf)
-                }
+                }}
                 #[inline]
                 pub fn finish_shard_buffer<'a, 'b, A: flatbuffers::Allocator + 'a>(
                     fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,


### PR DESCRIPTION
Since flatbuffers 25.9.23 also support edition 2024 and we are not using anything extra otherwise bump the Rust edition. PR with bumping flatbuffers is https://github.com/google/sedpack/pull/246