### PR TITLE
Run dependabot on npm monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
       - "javascript"
     # Run every Monday
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       timezone: "Europe/Zurich"
     # Group PRs to avoid having to rebase/merge too many
     groups:


### PR DESCRIPTION
Since the website is just a static website being deployed by GitHub there is rather low security risk.